### PR TITLE
Update main.tex

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -8,7 +8,8 @@
 \usepackage{aliascnt}
 \usepackage{ascmac}
 \usepackage{subfiles}
-
+\usepackage{hyperref}
+\usepackage{pxjahyper}
 
 %inoue.texより移動
 \usepackage{wrapfig}


### PR DESCRIPTION
`\usepackage{hyperref}` と `\usepackage{pxjahyper}` を加えると、PDFにしおりやハイパーリンクが備わります。Vol.7のPDFには付いていた機能です。